### PR TITLE
Fixed potential R bugs

### DIFF
--- a/src/ASMR/Analysis/RScripts/score.r
+++ b/src/ASMR/Analysis/RScripts/score.r
@@ -7,11 +7,16 @@
 args = commandArgs(trailingOnly = T)
 data.file = args[1]
 results.file = args[2]
+data.file = gsub("\\\\", "/", data.file)
+results.file = gsub("\\\\", "/", results.file)
 data.file.name = sub(pattern = "(.*)\\..*$", replacement = "\\1", basename(data.file))
 
 test.file = readLines(data.file, n = 1)
 test.results = read.csv(data.file, skip = 1)
 num.tests = nrow(test.results)
+
+test.results$Correct = factor(test.results$Correct, levels=c("no", "yes"))
+test.results$Subject = factor(test.results$Subject, levels=c("no", "yes"))
 
 plot.file.name = paste(data.file.name, "scores.png", sep = "_")
 plot.path = paste(dirname(results.file), plot.file.name, sep="/")


### PR DESCRIPTION
I rooted out and patched two potential bugs in the R script.

The bug related to factor levels occurs when the set of occurring answers (i.e. "yes" or "no") in the `Correct` column does not match that of the `Subject` column.

The other bug may occur when given a Windows file path. It is prevented by replacing each backslash `\` in the path with a forward slash `/`. I haven't actually tested if this is a bug because I do not have immediate access to a Windows machine, but it seems likely.