### PR TITLE
Fix final bug related to windows

### DIFF
--- a/src/ASMR/Analysis/RAnalysis.java
+++ b/src/ASMR/Analysis/RAnalysis.java
@@ -125,7 +125,7 @@ public class RAnalysis {
 		
 		try {
 			for (String line = results.readLine(); line != null; line = results.readLine()) {
-				String[] resultPair = line.split(":");
+				String[] resultPair = line.split("\\|");
 				String label = resultPair[0];
 				String value = resultPair[1];
 

--- a/src/ASMR/Analysis/RScripts/score.r
+++ b/src/ASMR/Analysis/RScripts/score.r
@@ -29,7 +29,7 @@ plot(c(0, test.results$Test.), c(0, test.results$Points), type = "b", main = plo
 prop.correct = length(test.results$Test.[test.results$Correct == test.results$Subject]) / nrow(test.results)
 final.score = tail(test.results$Points, n = 1)
 
-cat("TestFile:", test.file, "\n", sep = "")
-cat("NumberTests:", num.tests, "\n", sep = "")
-cat("ProportionCorrect:", prop.correct, "\n", sep = "")
-cat("FinalScore:", final.score, "\n", sep = "")
+cat("TestFile|", test.file, "\n", sep = "")
+cat("NumberTests|", num.tests, "\n", sep = "")
+cat("ProportionCorrect|", prop.correct, "\n", sep = "")
+cat("FinalScore|", final.score, "\n", sep = "")


### PR DESCRIPTION
Fixed a bug wherein the delimiter used (`:`) to obtain analysis results from R causes output errors when given a Windows letter drive file path that also contains that delimiter.

This was fixed by changing the delimiter to `|`.

This is probably the last analysis bug.